### PR TITLE
[Issue][Bug] NameError: global name 'escapeCMDWindows' is not defined

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Some useful tools to add to your sidebar context menu and command palette:
 - duplicate
 - open in default program
 
-This package offers a tiny optimised subset of commands from the original [SidebarEnhancements](https://packagecontrol.io/packages/SideBarEnhancements), striking a balance somwhere between the bare minimum and the kitchen sink.
+This package offers a tiny optimised subset of commands from the original [SidebarEnhancements](https://packagecontrol.io/packages/SideBarEnhancements), striking a balance somewhere between the bare minimum and the kitchen sink.
 
 - The default context menu isn't replaced, this package just adds some useful new commands.
 - It's tiny, fast and reliable.


### PR DESCRIPTION
### 1. Summary

`Open With Default` don't work for me. Images don't open, I get stack trace.

### 2. Expected behavior

Open my sidebar images in my default application for images.

### 3. Actual behavior

```python
command: side_bar_open {"paths": ["D:\\Kristinita\\themes\\sashapelican\\static\\images\\aside\\Надутые_губки.jpg"]}
Traceback (most recent call last):
  File "D:\Sublime Text 3 x64\sublime_plugin.py", line 795, in run_
    return self.run(**args)
  File "SideBar in D:\Sublime Text 3 x64\Data\Installed Packages\SideBarTools.sublime-package", line 170, in run
  File "SideBarAPI in D:\Sublime Text 3 x64\Data\Installed Packages\SideBarTools.sublime-package", line 369, in open
NameError: global name 'escapeCMDWindows' is not defined
```

### 4. Steps to reproduce

I reproduce the problem in a version of Sublime Text without plugins and user settings.

I install SideBar Tools → I restart Sublime Text → <kbd>Right_Click</kbd> to any image name in my sidebar → `Open With Default` → I get actual behavior.

### 5. Environment

**Operating system and version:**
Windows 10 Enterprise LTSB 64-bit EN
**Sublime Text:**
Build 3126


Thanks.