### PR TITLE
Add Move file command

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -23,5 +23,10 @@
 		"caption": "File: Duplicate",
 		"command": "side_bar_duplicate",
 		"args": { "paths": [] }
+	},
+	{
+		"caption": "File: Move",
+		"command": "side_bar_move",
+		"args": { "paths": [] }
 	}
 ]

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -21,5 +21,10 @@
 		"caption": "Duplicate…",
 		"command": "side_bar_duplicate",
 		"args": { "paths": [] }
+	},
+	{
+		"caption": "Move…",
+		"command": "side_bar_move",
+		"args": { "paths": [] }
 	}
 ]

--- a/SideBar.py
+++ b/SideBar.py
@@ -21,10 +21,6 @@ class SideBarCommand(sublime_plugin.WindowCommand):
 	def make_dirs_for(filename):
 		"""
 		Attempts to create all necessary subdirectories for `filename`.
-
-		Returns True if the tree was created, False otherwise, but doesn't
-		mean we can or cannot write to it. It simply means it was not created
-		by this function.
 		"""
 
 		destination_dir = os.path.dirname(filename)

--- a/SideBar.py
+++ b/SideBar.py
@@ -58,7 +58,6 @@ class SideBarCopyRelativePathCommand(SideBarCommand):
 class SideBarDuplicateCommand(SideBarCommand):
 
 	def run(self, paths):
-		self.view = self.window.active_view()
 		self.source = self.get_path(paths)
 		base, leaf = os.path.split(self.source)
 		name, ext = os.path.splitext(leaf)
@@ -76,39 +75,20 @@ class SideBarDuplicateCommand(SideBarCommand):
 			args=(self.source, destination)).start()
 
 	def copy(self, source, destination):
-		print(source, destination)
-		if self.view:
-			self.view.set_status('SideBarTools:Copy', 'copying "{}" to "{}"'.format(
-				source, destination))
-		else:
-			self.window.status_message('copying "{}" to "{}"'.format(
-				source, destination))
+		self.window.status_message('Copying "{}" to "{}"'.format(source, destination))
 
 		if os.path.isdir(source):
 			shutil.copytree(source, destination)
 		else:
 			shutil.copy2(source, destination)
 
-		if self.view:
-			self.view.erase_status('SideBarTools:Copy')
-
 	def description(self):
 		return 'Duplicate File…'
-
-
-def temporary_status_message(view, message, key='SideBarTools', duration=5000):
-	view.set_status(key, message)
-
-	def erase_status():
-		view.erase_status(key)
-
-	sublime.set_timeout_async(erase_status, duration)
 
 
 class SideBarMoveCommand(SideBarCommand):
 
 	def run(self, paths):
-		self.view = self.window.active_view()
 		self.source = self.get_path(paths)
 
 		input_panel = self.window.show_input_panel(
@@ -124,13 +104,7 @@ class SideBarMoveCommand(SideBarCommand):
 		threading.Thread(target=self.move, args=(self.source, destination)).start()
 
 	def move(self, source, destination):
-		print(source, destination)
-		if self.view:
-			self.view.set_status(
-				'SideBarTools:Move', 'Moving "{}" to "{}"'.format(source, destination))
-		else:
-			self.window.status_message(
-				'Moving "{}" to "{}"'.format(source, destination))
+		self.window.status_message('Moving "{}" to "{}"'.format(source, destination))
 
 		destination_dir = os.path.dirname(destination)
 		try:
@@ -138,25 +112,14 @@ class SideBarMoveCommand(SideBarCommand):
 		except OSError:
 			print('Destination directory seems to exists...')
 
-		if self.view:
-			self.view.erase_status('SideBarTools:Move')
-
 		try:
 			shutil.move(source, destination)
 		except OSError as error:
-			message = 'Error moving "{src}" to "{dst}": {error}'.format(
+			self.window.status_message('Error moving "{src}" to "{dst}": {error}'.format(
 				src=source,
 				dst=destination,
 				error=error,
-			)
-			if self.view:
-				temporary_status_message(
-					self.view,
-					message,
-					key='SideBarTools:Move'
-				)
-			else:
-				print(message)
+			))
 
 	def description(self):
 		return 'Move File…'

--- a/SideBar.py
+++ b/SideBar.py
@@ -77,7 +77,7 @@ class SideBarDuplicateCommand(SideBarCommand):
 
 	def run(self, paths):
 		self.source = self.get_path(paths)
-		base, leaf = os.path.split(self.source)
+		leaf = os.path.split(self.source)[1]
 		name, ext = os.path.splitext(leaf)
 		initial_text = name + ' (Copy)' + ext
 		input_panel = self.window.show_input_panel('Duplicate As:',
@@ -120,7 +120,7 @@ class SideBarMoveCommand(SideBarCommand):
 			'Move to:', self.source, self.on_done, None, None)
 
 		base, leaf = os.path.split(self.source)
-		name, ext = os.path.splitext(leaf)
+		ext = os.path.splitext(leaf)[1]
 
 		input_panel.sel().clear()
 		input_panel.sel().add(sublime.Region(len(base) + 1, len(self.source) - len(ext)))

--- a/SideBar.py
+++ b/SideBar.py
@@ -101,7 +101,7 @@ class SideBarDuplicateCommand(SideBarCommand):
 			else:
 				shutil.copy2(source, destination)
 		except OSError as error:
-			self.window.status_message('Error copying "{src}" to "{dst}": {error}'.format(
+			self.window.status_message('Error copying: {error} ("{src}" to "{dst}")'.format(
 				src=source,
 				dst=destination,
 				error=error,
@@ -136,7 +136,7 @@ class SideBarMoveCommand(SideBarCommand):
 		try:
 			shutil.move(source, destination)
 		except OSError as error:
-			self.window.status_message('Error moving "{src}" to "{dst}": {error}'.format(
+			self.window.status_message('Error moving: {error} ("{src}" to "{dst}")'.format(
 				src=source,
 				dst=destination,
 				error=error,

--- a/SideBar.py
+++ b/SideBar.py
@@ -95,11 +95,17 @@ class SideBarDuplicateCommand(SideBarCommand):
 		self.window.status_message('Copying "{}" to "{}"'.format(source, destination))
 
 		self.make_dirs_for(destination)
-
-		if os.path.isdir(source):
-			shutil.copytree(source, destination)
-		else:
-			shutil.copy2(source, destination)
+		try:
+			if os.path.isdir(source):
+				shutil.copytree(source, destination)
+			else:
+				shutil.copy2(source, destination)
+		except OSError as error:
+			self.window.status_message('Error copying "{src}" to "{dst}": {error}'.format(
+				src=source,
+				dst=destination,
+				error=error,
+			))
 
 	def description(self):
 		return 'Duplicate File…'

--- a/SideBar.py
+++ b/SideBar.py
@@ -94,3 +94,69 @@ class SideBarDuplicateCommand(SideBarCommand):
 
 	def description(self):
 		return 'Duplicate File…'
+
+
+def temporary_status_message(view, message, key='SideBarTools', duration=5000):
+	view.set_status(key, message)
+
+	def erase_status():
+		view.erase_status(key)
+
+	sublime.set_timeout_async(erase_status, duration)
+
+
+class SideBarMoveCommand(SideBarCommand):
+
+	def run(self, paths):
+		self.view = self.window.active_view()
+		self.source = self.get_path(paths)
+
+		input_panel = self.window.show_input_panel(
+			'Move to:', self.source, self.on_done, None, None)
+
+		base, leaf = os.path.split(self.source)
+		name, ext = os.path.splitext(leaf)
+
+		input_panel.sel().clear()
+		input_panel.sel().add(sublime.Region(len(base) + 1, len(self.source) - len(ext)))
+
+	def on_done(self, destination):
+		threading.Thread(target=self.move, args=(self.source, destination)).start()
+
+	def move(self, source, destination):
+		print(source, destination)
+		if self.view:
+			self.view.set_status(
+				'SideBarTools:Move', 'Moving "{}" to "{}"'.format(source, destination))
+		else:
+			self.window.status_message(
+				'Moving "{}" to "{}"'.format(source, destination))
+
+		destination_dir = os.path.dirname(destination)
+		try:
+			os.makedirs(destination_dir)
+		except OSError:
+			print('Destination directory seems to exists...')
+
+		if self.view:
+			self.view.erase_status('SideBarTools:Move')
+
+		try:
+			shutil.move(source, destination)
+		except OSError as error:
+			message = 'Error moving "{src}" to "{dst}": {error}'.format(
+				src=source,
+				dst=destination,
+				error=error,
+			)
+			if self.view:
+				temporary_status_message(
+					self.view,
+					message,
+					key='SideBarTools:Move'
+				)
+			else:
+				print(message)
+
+	def description(self):
+		return 'Move File…'

--- a/SideBar.py
+++ b/SideBar.py
@@ -78,7 +78,7 @@ class SideBarDuplicateCommand(SideBarCommand):
 	def copy(self, source, destination):
 		print(source, destination)
 		if self.view:
-			self.view.set_status('ZZZ', 'copying "{}" to "{}"'.format(
+			self.view.set_status('SideBarTools:Copy', 'copying "{}" to "{}"'.format(
 				source, destination))
 		else:
 			self.window.status_message('copying "{}" to "{}"'.format(
@@ -90,7 +90,7 @@ class SideBarDuplicateCommand(SideBarCommand):
 			shutil.copy2(source, destination)
 
 		if self.view:
-			self.view.erase_status('ZZZ')
+			self.view.erase_status('SideBarTools:Copy')
 
 	def description(self):
 		return 'Duplicate File…'


### PR DESCRIPTION
This commands presents the full path of the file to be moved, allowing the user to type the destination and renaming it in just one operation.

If an error with the move operation occurs, a temporary message will be shown in the status bar of the current view, and it will be discarded after 5 seconds.

Fixes #5