### PR TITLE
Prevent file-related menus to be visible for views with no file associated

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -19,7 +19,9 @@ class SideBarCommand(sublime_plugin.WindowCommand):
             return self.window.active_view().file_name()
 
     def is_visible(self, paths):
-        return len(paths) < 2
+        if paths:
+            return len(paths) < 2
+        return bool(self.window.active_view().file_name())
 
     @staticmethod
     def make_dirs_for(filename):


### PR DESCRIPTION
`sublime_plugin.WindowCommand.is_visible`'s `paths` argument is empty for new, unsaved views (like after hitting `Ctrl/Cmd+N`), so currently the menu will be visible, but crash when trying to manipulate an empty string as a path.