### PR TITLE
fix #19 program hangs on dotfile with extension

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -102,6 +102,8 @@ class SideBarDuplicateCommand(SideBarCommand):
             while '.' in name:
                 name, _ext = os.path.splitext(name)
                 ext = _ext + ext
+                if _ext is '':
+                    break
 
         initial_text = name + ' (Copy)' + ext
         input_panel = self.window.show_input_panel(


### PR DESCRIPTION
Resolves #19. There are several ways to handle this edge case, I believe checking `_ext` is sufficient as it should only be blank if `name` has only one `.` and that is at the beginning.