### PR TITLE
Commands: Remove duplicate entry for “move”

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -30,11 +30,6 @@
 		"args": { "paths": [] }
 	},
 	{
-		"caption": "File: Move",
-		"command": "side_bar_move",
-		"args": { "paths": [] }
-	},
-	{
 		"caption": "Preferences: SideBarTools Settings",
 		"command": "edit_settings",
 		"args":


### PR DESCRIPTION
There were two identical command definitions for “File: Move”.
This resulted in two identical entries when pressing ⌘⇧P / ⌃⇧P.