### PR TITLE
[Feature] Delete and New File Commands

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -37,5 +37,29 @@
 		    "base_file": "${packages}/SideBarTools/SideBarTools.sublime-settings",
 		    "default": "// SideBarTools Settings - User\n{\n\t$0\n}\n"
 		}
+	},
+	{
+		"caption": "File: Delete",
+		"command": "side_bar_delete"
+	},
+	{
+		"caption": "File: Delete and Close",
+		"command": "side_bar_delete",
+		"args": { "close": true }
+	},
+	{
+		"caption": "File: New Relative To Current File",
+		"command": "side_bar_new_file",
+		"args": { "base": "file_path" }
+	},
+	{
+		"caption": "File: New Relative To Project Root",
+		"command": "side_bar_new_file",
+		"args": { "base": "project_path" }
+	},
+	{
+		"caption": "File: New Relative To Base Folder",
+		"command": "side_bar_new_file",
+		"args": { "base": "folder" }
 	}
 ]


### PR DESCRIPTION
First of all, thanks for creating _SideBarTools._ My side bar looks much cleaner than with _SideBarEnhancements,_ and having no tracking code in there is great.

Something I am missing is functionality to create and delete files easily from the command palette. I have implemented “File: Delete …” and “File: New Relative To …”. Check the commit message below for details.

This is not  ready for merging, as at the very least the Readme will need updating. And I wanted to check whether you want these commands in your package at all, since this is not strictly side bar functionality.


- - - 

Adds two new command implementations that are intended for use from the command palette:

- `SideBarDeleteCommand` is exposed as
  - “File: Delete”, where the file is deleted, but the current tab remains open
  - “File: Delete and Close”, where the current tab is closed after deletion. Any other tabs stay open.

- `SideBarNewCommand` is a command where the user enters a file name immediately, and the file is created before opening it in a tab. It comes in three version:
  - “File: New Relative To Current File” is enabled when the current tab has an associated file name. The folder containing the current file is used as base for the new file.
  - “File: New Relative To Project Root” is only enabled when within a project, and uses the directory containing the project file as base.
  - “File: New Relative To Base Folder” is only enabled when the side bar has at least one folder open, which will be the base directory for the new file. If the side bar shows more than one folder, the user is presented with a selection dialogue.