### PR TITLE
Fix for view.file_name() being None

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -213,7 +213,9 @@ class SideBarMoveCommand(SideBarCommand):
 
         for window in sublime.windows():
             for view in window.views():
-                filename = view.file_name() or ''
+                filename = view.file_name()
+                if not filename:
+                    continue
                 if os.path.commonprefix([source, filename]) == source:
                     view.retarget(
                         os.path.join(destination, filename[len(source):])
@@ -225,7 +227,10 @@ class SideBarMoveCommand(SideBarCommand):
         destination = os.path.normcase(os.path.abspath(destination))
         for window in sublime.windows():
             for view in window.views():
-                path = os.path.abspath(view.file_name() or '')
+                filename = view.file_name()
+                if not filename:
+                    continue
+                path = os.path.abspath(filename)
                 if os.path.normcase(path) == source:
                     view.retarget(destination)
 

--- a/SideBar.py
+++ b/SideBar.py
@@ -213,7 +213,7 @@ class SideBarMoveCommand(SideBarCommand):
 
         for window in sublime.windows():
             for view in window.views():
-                filename = view.file_name()
+                filename = view.file_name() or ''
                 if os.path.commonprefix([source, filename]) == source:
                     view.retarget(
                         os.path.join(destination, filename[len(source):])
@@ -225,7 +225,7 @@ class SideBarMoveCommand(SideBarCommand):
         destination = os.path.normcase(os.path.abspath(destination))
         for window in sublime.windows():
             for view in window.views():
-                path = os.path.abspath(view.file_name())
+                path = os.path.abspath(view.file_name() or '')
                 if os.path.normcase(path) == source:
                     view.retarget(destination)
 


### PR DESCRIPTION
If there is a window with no tabs open, or a tab which has not yet been saved to disk, `view.file_name()` will be `None` so retargeting the view breaks. This fixes that issue