### PR TITLE
Enable compare when using list of arguments

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -53,7 +53,7 @@ class SideBarCommand(sublime_plugin.WindowCommand):
 class SideBarCompareCommand(sublime_plugin.WindowCommand):
 
     def is_visible(self, paths):
-        return len(paths) == 2 and get_setting(self, 'difftool')
+        return len(paths) == 2 and bool(get_setting(self, 'difftool'))
 
     def is_enabled(self, paths):
         if len(paths) < 2 or not get_setting(self, 'difftool'):


### PR DESCRIPTION
Trying to use smerge for the diff

  // SideBarTools Settings - User
  {
	 "difftool": ["smerge", "mergetool"]
  }

Selecting two files and right clicking results in an error in the console:

  Traceback (most recent call last):
    File "C:\Program Files\Sublime Text\Lib\python38\sublime_plugin.py", line 1383, in is_visible_
    raise ValueError("is_visible must return a bool", self)
  ValueError: ('is_visible must return a bool', <SideBarTools.SideBar.SideBarCompareCommand object at 0x000001CBB79A0280>)

and the Compare command is not displayed in the side bar.

This change updates the check to handle the case where the difftool setting is a list of command line arguments instead of a simple string or bool.