### PR TITLE
Allow copy file commands to be called without arguments

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -81,7 +81,7 @@ class MultipleFilesMixin(object):
 
 class SideBarCopyNameCommand(MultipleFilesMixin, SideBarCommand):
 
-    def run(self, paths):
+    def run(self, paths=[]):
         names = (os.path.split(path)[1] for path in self.get_paths(paths))
         self.copy_to_clipboard_and_inform('\n'.join(names))
 
@@ -91,7 +91,7 @@ class SideBarCopyNameCommand(MultipleFilesMixin, SideBarCommand):
 
 class SideBarCopyAbsolutePathCommand(MultipleFilesMixin, SideBarCommand):
 
-    def run(self, paths):
+    def run(self, paths=[]):
         paths = self.get_paths(paths)
         self.copy_to_clipboard_and_inform('\n'.join(paths))
 
@@ -101,7 +101,7 @@ class SideBarCopyAbsolutePathCommand(MultipleFilesMixin, SideBarCommand):
 
 class SideBarCopyRelativePathCommand(MultipleFilesMixin, SideBarCommand):
 
-    def run(self, paths):
+    def run(self, paths=[]):
         paths = self.get_paths(paths)
         root_paths = self.window.folders()
         relative_paths = []


### PR DESCRIPTION
The paths argument is empty by default. Making it optional allows creating keymaps without needing specify an empty paths argument. 

For example, I use NeoVintageous, which has a current limitation in that it can't take list argument values, so with this change I can map to the commands without any arguments:

```
nnoremap <leader>ca :SideBarCopyAbsolutePath<CR>
nnoremap <leader>cn :SideBarCopyName<CR>
nnoremap <leader>cr :SideBarCopyRelativePath<CR>
```
