### PR TITLE
fix: nonetype error when creating new folder

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -316,7 +316,7 @@ class SideBarNewCommand(SideBarCommand):
         source = self.get_path(paths)
         select_extension = False
 
-        if not os.path.exists(source):
+        if source is None or not os.path.exists(source):
             self.window.status_message('No path to create a new file from.')
             return
 


### PR DESCRIPTION
The new command uses the active view file name as the path from which to construct the new folder, but when the view is empty there is no real file on disk and the file name is None.

The `os.path` functions like `isdir` and `exists` raise a NoneType exception when given None. This patch adds a NoneType check.

Close #55
Re #56